### PR TITLE
Use 'base' scoped searches

### DIFF
--- a/__test__/client.spec.js
+++ b/__test__/client.spec.js
@@ -116,6 +116,19 @@ describe('Client', () => {
     await client.destroy();
   });
 
+  it ('search w/ base scope', async () => {
+    const client = new Client({ url: 'ldap://www.zflexldap.com' });
+
+    await client.bind('cn=ro_admin,ou=sysadmins,dc=zflexsoftware,dc=com', 'zflexpass');
+    
+    try {
+      const response = await client.search('ou=guests,dc=zflexsoftware,dc=com', { scope: 'base' });
+      expect(response.length).toBeGreaterThanOrEqual(0);
+    } catch (e) {
+      expect(false).toBeTruthy();
+    }
+  });
+
   it('search not found', async () => {
     expect.assertions(2);
 

--- a/src/requests/search_request.js
+++ b/src/requests/search_request.js
@@ -15,11 +15,13 @@ module.exports = class extends Request {
   }
 
   set scope(val) {
-    this._scope = SCOPES[val];
+    const found = Object.getOwnPropertyNames(SCOPES).find(scope => scope === val);
 
-    if (!this._scope) {
+    if (!found) {
       throw new Error(`${val} is an invalid search scope`);
     }
+
+    this._scope = SCOPES[val];
   }
 
   _toBer(ber) {


### PR DESCRIPTION
This PR attempts to fix the error 'Error: base is an invalid search scope'. when scope = 'base' on the search options.
