### PR TITLE
Prevent application crash on incomming message without queue message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,21 +27,24 @@ class Client {
       if (msg instanceof SearchEntry || msg instanceof SearchReference) {
         this._queue.get(msg.id).result.push(msg.object);
       } else {
-        const { resolve, reject, result, request } = this._queue.get(msg.id);
+        const qItem = this._queue.get(msg.id);
+        if (qItem) {
+          const { resolve, reject, result, request } = qItem;
 
-        if (msg instanceof Response) {
+          if (msg instanceof Response) {
           if (msg.status !== LDAP_SUCCESS) {
             reject(getError(msg));
           }
 
           resolve(request instanceof Search ? result : msg.object);
-        } else if (msg instanceof Error) {
+          } else if (msg instanceof Error) {
           reject(msg);
-        } else {
+          } else {
           reject(new ProtocolError(msg.type));
-        }
+          }
 
-        this._queue.delete(msg.id);
+          this._queue.delete(msg.id);
+        }
       }
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,15 +32,15 @@ class Client {
           const { resolve, reject, result, request } = qItem;
 
           if (msg instanceof Response) {
-          if (msg.status !== LDAP_SUCCESS) {
-            reject(getError(msg));
-          }
+            if (msg.status !== LDAP_SUCCESS) {
+              reject(getError(msg));
+            }
 
-          resolve(request instanceof Search ? result : msg.object);
+            resolve(request instanceof Search ? result : msg.object);
           } else if (msg instanceof Error) {
-          reject(msg);
+            reject(msg);
           } else {
-          reject(new ProtocolError(msg.type));
+            reject(new ProtocolError(msg.type));
           }
 
           this._queue.delete(msg.id);


### PR DESCRIPTION
After a timeout the message is removed from the queue, but the message still comes in and cannot find a corresponding message in the queue. This resulted in the error message:
`Cannot destructure property 'resolve' of 'this._queue.get(...)' as it is undefined`