### PR TITLE
patch equality_filter

### DIFF
--- a/src/filters/equality_filter.js
+++ b/src/filters/equality_filter.js
@@ -32,7 +32,9 @@ module.exports = class EqualityFilter extends parents.EqualityFilter {
 
   toBer(ber) {
     assert.ok(ber instanceof BerWriter, 'ber (BerWriter) required');
-
+    if (this.attribute.toLowerCase() === 'objectguid'){
+      this.raw = Buffer.from(this.value,'binary');
+    }
     ber.startSequence(FILTER_EQUALITY);
     ber.writeString(this.attribute);
     ber.writeBuffer(this.raw, OctetString);


### PR DESCRIPTION
We have a requirement to make LDAP searches using 'objectguid' which is stored as a binary field in the LDAP servers.

Currently when the filter string is parsed using escaped hex values, the escape function assumes all given values will be ascii printable characters (ie values less than 0x7f). Due to this the returned string may contain 0xc2 followed by the escaped hex value. 

These extra bytes cause the search to fail, and return no results.

I've limited the change to only check for the objectguid attribute, as i'm unsure if there would ever be some arbitrary attribute that might expect these control bytes to be present.

Unfortunately the ldap.forumsys.com test LDAP server does not appear to have any fields that are store as binary so I'm unable to accurately test against these servers.

Example:
```javascript
// example.js
const LdapClient = require('ldapjs-client');

const url = 'ldap://ldap.forumsys.com';
const user = 'cn=read-only-admin,dc=example,dc=com';
const password = 'password';

const main = async () => {
  const client = new LdapClient({
    url,
    timeout: 5000
  });
  console.log('binding');
  await client.bind(user, password);
  const options = {
    filter: `(&(objectclass=group)(objectguid=\\90\\91\\92\\93\\94\\95\\96\\97\\98\\99\\9a\\9b\\9c\\9d\\9e\\9f))`,
    scope: 'sub',
    attributes: ['*'],
  };

  console.log('searching');
  const entries = await client.search('ou=scientists,dc=example,dc=com', options);
// received: <Buffer c2 90 c2 91 c2 92 c2 93 c2 94 c2 95 c2 96 c2 97 c2 98 c2 99 c2 9a c2 9b c2 9c c2 9d c2 9e c2 9f>
// expected: <Buffer 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f>

  console.log('results');
  for (let i =0;i<entries.length;i++){
    console.log(entries[i]);
  }
  return;
};

main();
```