### PR TITLE
add support for paged queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ scope | String | One of base, one, or sub. Defaults to base
 filter | String | A string version of an LDAP filter. Defaults to (objectclass=*)
 attributes | Array of String | attributes to select and return. Defaults to the empty set, which means all attributes
 sizeLimit | Number | the maximum number of entries to return. Defaults to 0 (unlimited)
+pageSize | Number | Page size for paged search. If this attribute is set, search results are retrieved in pages. ActiveDirectory has a default limit of 1000 returned entries. If a larger number of results is expected, this attribute should be set
 timeLimit | Number | the maximum amount of time the server should take in responding, in seconds. Defaults to 10. Lots of servers will ignore this
 typesOnly | Boolean | on whether you want the server to only return the names of the attributes, and not their values. Borderline useless. Defaults to false
 cookie | string | For handling paged results, set an empty string initally

--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ try {
 } catch (e) {
   console.log(e);
 }
+
+// paged response
+try {
+  const options = {
+    filter: '(&(l=Seattle)(email=*@foo.com))',
+    scope: 'sub',
+    attributes: ['dn', 'sn', 'cn'],
+    sizeLimit: 1000
+  };
+
+let hasNext = true;
+  let cookie = '';
+  let response = [];
+  while(hasNext){
+    let sizeLimit = 100;
+    const result = await client.search('o=example', { scope: 'sub', sizeLimit, cookie });
+    console.log(result);
+    if (result.length === sizeLimit+1){
+      const tmp = result.pop();
+      hasNext = tmp.hasNext;
+      cookie = tmp.cookie;
+      response = response.concat(result);
+    }
+  }
+
+  console.log(response);
+} catch (e) {
+  console.log(e);
+}
 ```
 
 Attribute | Type | Description
@@ -111,6 +140,7 @@ attributes | Array of String | attributes to select and return. Defaults to the 
 sizeLimit | Number | the maximum number of entries to return. Defaults to 0 (unlimited)
 timeLimit | Number | the maximum amount of time the server should take in responding, in seconds. Defaults to 10. Lots of servers will ignore this
 typesOnly | Boolean | on whether you want the server to only return the names of the attributes, and not their values. Borderline useless. Defaults to false
+cookie | string | For handling paged results, set an empty string initally
 
 ### unbind
 ```js

--- a/README.md
+++ b/README.md
@@ -108,20 +108,19 @@ try {
     filter: '(&(l=Seattle)(email=*@foo.com))',
     scope: 'sub',
     attributes: ['dn', 'sn', 'cn'],
-    sizeLimit: 1000
+    pageLimit: 1000,
+    cookie: ''
   };
 
-let hasNext = true;
-  let cookie = '';
+  let hasNext = true;
   let response = [];
   while(hasNext){
-    let sizeLimit = 100;
-    const result = await client.search('o=example', { scope: 'sub', sizeLimit, cookie });
+    const result = await client.search('o=example', options);
     console.log(result);
-    if (result.length === sizeLimit+1){
+    if (result.length === options.pageLimit+1){
       const tmp = result.pop();
       hasNext = tmp.hasNext;
-      cookie = tmp.cookie;
+      options.cookie = tmp.cookie;
       response = response.concat(result);
     }
   }

--- a/__test__/client.spec.js
+++ b/__test__/client.spec.js
@@ -122,7 +122,7 @@ describe('Client', () => {
     await client.destroy();
   });
 
-  it ('search w/ base scope', async () => {
+  it('search w/ base scope', async () => {
     const client = new Client({ url });
 
     await client.bind(user, password);
@@ -147,6 +147,32 @@ describe('Client', () => {
 
     expect(Array.isArray(response)).toBeTruthy();
     expect(response.length).toBe(0);
+
+    await client.destroy();
+  });
+
+  it('paged search', async () => {
+    const client = new Client({ url });
+    await client.bind(user, password);
+    const sizeLimit = 1;
+    let cookie = '';
+    let hasNext = true;
+    let i = 0;
+    let response = [];
+    while (hasNext && i < 5) {
+      const result = await client.search('ou=scientists,dc=example,dc=com', { scope: 'sub', sizeLimit, filters: '(objectclass=*)', attributes: ['cn'], cookie });
+      if (result.length === sizeLimit + 1) {
+        const tmp = result.pop();
+        hasNext = tmp.hasNext;
+        cookie = tmp.cookie;
+        response = response.concat(result);
+      }
+      i += 1;
+    }
+
+    expect(Array.isArray(response)).toBeTruthy();
+    expect(response.length).toBe(2);
+    expect(i).toBe(2);
 
     await client.destroy();
   });

--- a/__test__/client.spec.js
+++ b/__test__/client.spec.js
@@ -154,14 +154,14 @@ describe('Client', () => {
   it('paged search', async () => {
     const client = new Client({ url });
     await client.bind(user, password);
-    const sizeLimit = 1;
+    const pageSize = 1;
     let cookie = '';
     let hasNext = true;
     let i = 0;
     let response = [];
     while (hasNext && i < 5) {
-      const result = await client.search('ou=scientists,dc=example,dc=com', { scope: 'sub', sizeLimit, filters: '(objectclass=*)', attributes: ['cn'], cookie });
-      if (result.length === sizeLimit + 1) {
+      const result = await client.search('ou=scientists,dc=example,dc=com', { scope: 'sub', pageSize, filters: '(objectclass=*)', attributes: ['cn'], cookie });
+      if (result.length === pageSize + 1) {
         const tmp = result.pop();
         hasNext = tmp.hasNext;
         cookie = tmp.cookie;

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,7 @@ class Client {
     assert.optionalString(options.scope, 'options.scope');
     assert.optionalString(options.filter, 'options.filter');
     assert.optionalNumber(options.sizeLimit, 'options.sizeLimit');
+    assert.optionalNumber(options.pageSize, 'options.pageSize');
     assert.optionalNumber(options.timeLimit, 'options.timeLimit');
     assert.optionalArrayOfString(options.attributes, 'options.attributes');
 

--- a/src/requests/request.js
+++ b/src/requests/request.js
@@ -22,7 +22,7 @@ module.exports = class {
     writer = this._toBer(writer);
     writer.endSequence();
     // add pagination control if sizeLimit is set
-    if (this.sizeLimit > 0 && this.sizeLimit <= MAX_INT) {
+    if (this.pageSize > 0 && this.pageSize <= MAX_INT) {
       writer.startSequence(LDAP_CONTROLS);
       writer.startSequence(); // Control
       writer.writeString(SIMPLE_PAGED_RESULTS);
@@ -31,7 +31,7 @@ module.exports = class {
       // reference https://docs.ldap.com/specs/rfc2696.txt
       let tmpWriter = new BerWriter();
       tmpWriter.startSequence();
-      tmpWriter.writeInt(this.sizeLimit); // might need to assert this is a number
+      tmpWriter.writeInt(this.pageSize); // might need to assert this is a number
       tmpWriter.writeString(this.cookie);
 
       tmpWriter.endSequence(); // end control value

--- a/src/requests/request.js
+++ b/src/requests/request.js
@@ -1,8 +1,11 @@
 const { BerWriter } = require('asn1');
+const { LDAP_CONTROLS } = require('../utils/protocol');
+const { SIMPLE_PAGED_RESULTS } = require('../utils/ldapoid');
 
+const MAX_INT = 2147483647; // 2**31-1
 let id = 0;
 const nextID = () => {
-  id = Math.max(1, (id + 1) % 2147483647);
+  id = Math.max(1, (id + 1) % MAX_INT);
   return id;
 };
 
@@ -18,6 +21,26 @@ module.exports = class {
     writer.startSequence(this.protocolOp);
     writer = this._toBer(writer);
     writer.endSequence();
+    // add pagination control if sizeLimit is set
+    if (this.sizeLimit > 0 && this.sizeLimit <= MAX_INT) {
+      writer.startSequence(LDAP_CONTROLS);
+      writer.startSequence(); // Control
+      writer.writeString(SIMPLE_PAGED_RESULTS);
+
+      // search control value
+      // reference https://docs.ldap.com/specs/rfc2696.txt
+      let tmpWriter = new BerWriter();
+      tmpWriter.startSequence();
+      tmpWriter.writeInt(this.sizeLimit); // might need to assert this is a number
+      tmpWriter.writeString(this.cookie);
+
+      tmpWriter.endSequence(); // end control value
+      let controlValue = tmpWriter.buffer.toString('binary'); // control value is a BER encoded string
+      writer.writeString(controlValue);
+
+      writer.endSequence(); // End of Control
+      writer.endSequence(); // End of LDAP Controls
+    }
     writer.endSequence();
     return writer.buffer;
   }

--- a/src/requests/search_request.js
+++ b/src/requests/search_request.js
@@ -26,7 +26,7 @@ module.exports = class extends Request {
     ber.writeString(this.baseObject.toString());
     ber.writeEnumeration(this._scope);
     ber.writeEnumeration(NEVER_DEREF_ALIASES);
-    ber.writeInt(this.sizeLimit); 
+    ber.writeInt(this.sizeLimit);
     ber.writeInt(this.timeLimit);
     ber.writeBoolean(this.typesOnly);
 

--- a/src/requests/search_request.js
+++ b/src/requests/search_request.js
@@ -26,16 +26,7 @@ module.exports = class extends Request {
     ber.writeString(this.baseObject.toString());
     ber.writeEnumeration(this._scope);
     ber.writeEnumeration(NEVER_DEREF_ALIASES);
-    // If sizeLimit is between 0 and 2**31-1 this will cause server to return only that many results. 
-    // However, if the server contains more records than the given size limit it will 
-    // return EC 4 (SizeLimitExceeded).
-    // Simialarly if sizeLimit is set to high value, but the server has a default max
-    // sizeLimit that is smaller it will only return the max size limit set by the server again resulting
-    // in EC 4.
-    // To overcome this we need to use LDAP reqeust/response controls to be able to page the results.
-    // Additionally if EC 4 is given, when a sizeLimit greater than 0 is given
-    //  no response controls will be given and the request simply errs.
-    ber.writeInt(0); // sizeLimit, set to ulimited and use sizeLimit to control page size via controls
+    ber.writeInt(this.sizeLimit); 
     ber.writeInt(this.timeLimit);
     ber.writeBoolean(this.typesOnly);
 

--- a/src/responses/response.js
+++ b/src/responses/response.js
@@ -1,4 +1,5 @@
 const assert = require('assert-plus');
+const { Ber } = require('asn1');
 const { LDAP_REP_REFERRAL, LDAP_CONTROLS } = require('../utils/protocol');
 
 module.exports = class {
@@ -33,8 +34,8 @@ module.exports = class {
         ber.readSequence();
         let control = {
           tag: ber.readString(),
-          criticality: ber.peek() === 1 ? ber.readBoolean() : false,
-          controlValue: ber.peek() === 4 ? ber.readString() : ''
+          criticality: ber.peek() === Ber.Boolean ? ber.readBoolean() : false,
+          controlValue: ber.peek() === Ber.OctetString ? ber.readString() : ''
         };
         this.controls.push(control);
       }

--- a/src/utils/ldapoid.js
+++ b/src/utils/ldapoid.js
@@ -1,0 +1,4 @@
+// reference: https://ldap.com/ldap-oid-reference-guide/
+module.exports = {
+  SIMPLE_PAGED_RESULTS: '1.2.840.113556.1.4.319'
+};


### PR DESCRIPTION
We have a need to perform some larger queries that will exceed the configured servers sizeLimit of 1000. Currently simply setting size limit to a value less than the total number of rows that would be return results in a SizeLimitExceededError. 

example
```js
const Client = require('ldapjs-client');

const main = async () => {
  const url = 'ldap://ldap.forumsys.com';
  const user = 'cn=read-only-admin,dc=example,dc=com';
  const password = 'password';

  const client = new Client({ url });

  await client.bind(user, password);
  const result = await client.search('ou=scientists,dc=example,dc=com', { scope: 'sub', sizeLimit: 1});

  console.log(result);
};

main();

// received
/*
LDAPError [SizeLimitExceededError]: null
    at Parser.<anonymous> (C:\Users\***\git\sandbox\node_modules\ldapjs-client\src\index.js:37:22)
    at Parser.emit (node:events:517:28)
    at Parser.parse (C:\Users\***\git\sandbox\node_modules\ldapjs-client\src\responses\parser.js:57:12)
    at Parser.parse (C:\Users\***\git\sandbox\node_modules\ldapjs-client\src\responses\parser.js:68:12)
    at Socket.<anonymous> (C:\Users\****\git\sandbox\node_modules\ldapjs-client\src\index.js:168:22)
    at Socket.emit (node:events:517:28)
    at addChunk (node:internal/streams/readable:368:12)
    at readableAddChunk (node:internal/streams/readable:341:9)
    at Readable.push (node:internal/streams/readable:278:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  lde_message: null,
  lde_dn: null
}
*/

// expected
/*
[
  {
    dn: 'ou=scientists,dc=example,dc=com',
    uniqueMember: [
      'uid=einstein,dc=example,dc=com',
      'uid=tesla,dc=example,dc=com',
      'uid=newton,dc=example,dc=com',
      'uid=galileo,dc=example,dc=com'
    ],
    ou: 'scientists',
    cn: 'Scientists',
    objectClass: [ 'groupOfUniqueNames', 'top' ]
  }
]
*/
```

Added support for the SIMPLE_PAGED_RESULT OID control. Attempted to make the changes in the least invasive way i could think.

The only external change to the existing API is that when you specify a pageSize option, you should also add a empty string called `cookie` to the options as well. The cookie is required for the server to be able to track where in the results you are when submitting subsequent requests, and will be an empty string when there are no more pages.

Check __test__/client.spec.js for an example of how to page over all results.