### PR TITLE
fix infinte loop in parser.parse()

### DIFF
--- a/src/responses/parser.js
+++ b/src/responses/parser.js
@@ -38,7 +38,13 @@ class Parser extends EventEmitter {
       return;
     }
 
-    if (ber.remain < ber.length) {
+    // If ber.length == 0, then we do not have a complete chunk
+    // and can't proceed with parsing.
+    // Allowing this function to continue results in an infinite loop
+    // and due to the recursive nature of this function quickly 
+    // hits the stack call size limit.
+    // This only happens with very large responses.
+    if (ber.remain < ber.length || ber.length === 0) {
       return;
     }
 


### PR DESCRIPTION
Occasionally, when performing queries with large responses, the parser function sometimes gets stuck in an infinite loop. It appears the socket does not write only complete chunks, but will occasionally write a full chunk + plus a couple of bytes into the next chunk. usually something to the effect of `[0x30, 0x84,0x00,0x00,0x00]` as you can see this is the start of a sequence using a variable length byte encoding, but is missing the 6th byte.  Because of this the parser will just keep recursing with this partial sequence message until it hits the stack call limit. 

If we do a check to make sure the berReader has a length of 0 we just return since we know for sure there is not enough data in the buffer to proceed.

Example (pre-fix)
![image](https://github.com/user-attachments/assets/6f9c0036-a69f-4195-bc1e-c054e97005aa)

(post-fix)
![image](https://github.com/user-attachments/assets/4559752e-ba83-4cea-8809-51b4b5e2db8d)
